### PR TITLE
Add option `failOnError` which allows error to be reported to gulp if there are any linting errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ var configParser = require('./config_parser');
 
 module.exports = function(options) {
   var rc = new RcLoader('.pug-lintrc', options);
+  var totalErrors = 0;
 
   return through.obj(function(file, enc, cb) {
     if (file.isNull()) {
@@ -34,6 +35,7 @@ module.exports = function(options) {
           errors.forEach(function(error) {
             gutil.log(error.message);
           });
+          totalErrors += errors.length;
         }
       } catch (errLint) {
         return cb(new gutil.PluginError('gulp-pug-lint', errLint));
@@ -42,6 +44,12 @@ module.exports = function(options) {
       cb(null, file);
     });
 
+  }, function(cb) {
+    if (options && options.failOnError && totalErrors > 0) {
+      cb(new gutil.PluginError('gulp-pug-lint', 'Failed with ' + totalErrors + ' errors'));
+    } else {
+      cb();
+    }
   });
 
 };


### PR DESCRIPTION
Currently if there are any linting errors, this plugin just prints on the console.

This will allow users to fail the gulp task (and return a non-zero exit code) if there are any linting errors. This is useful when a non-zero exit code is used to identify a failed job (for example, a CI build).

This also solved #6 